### PR TITLE
Added executables to ignore and screen help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Executables in the build dir
+build/*

--- a/allinone/root/aio-screen
+++ b/allinone/root/aio-screen
@@ -1,0 +1,31 @@
+
+sessionname fsaaas
+
+# Start an empty shell at the front of the line
+screen -t system 0
+
+# Start the services
+ screen -t syndicate 1
+ stuff "systemctl start synd && journalctl -f -u synd\012"
+
+ screen -t syndicate-client 2
+
+ screen -t oort-valued 3
+ stuff "systemctl start oort-valued && journalctl -f -u oort-valued\012"
+
+ screen -t oort-group 4
+ stuff "systemctl start oort-groupd && journalctl -f -u oort-groupd\012"
+
+ screen -t oort-cli 5
+
+ screen -t formicd 6
+ stuff "systemctl start formicd && journalctl -f -u formicd\012"
+
+ screen -t cfsfuse 7
+
+ screen -t testbed 8
+
+ screen -t acctd 9
+
+ screen -t oohhc-cli 10
+


### PR DESCRIPTION
Added build/\* to .gitignore so executables in that directory are not tracked in git.  Added
a .screen file to help with working with the allinone.
